### PR TITLE
create iam users dynamically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 .terraform/
+*.tfstate

--- a/aws/dev/main.tf
+++ b/aws/dev/main.tf
@@ -1,13 +1,6 @@
+data "aws_caller_identity" "this" {}
+
 module "bootstrap" {
   source = "../modules/bootstrap/"
-  name = "shawnb"
-}
-
-output "name" {
-  value = module.bootstrap.name
-}
-
-output "password" {
-  value = module.bootstrap.password
-  sensitive = true
+  users  = var.aws_users
 }

--- a/aws/dev/tofu.tf
+++ b/aws/dev/tofu.tf
@@ -14,5 +14,5 @@ terraform {
 
 provider "aws" {
   profile = "bc-dev"
-  region = "us-east-1"
+  region  = "us-east-1"
 }

--- a/aws/modules/bootstrap/main.tf
+++ b/aws/modules/bootstrap/main.tf
@@ -3,12 +3,15 @@ resource "aws_iam_user" "terraform" {
 }
 
 resource "aws_iam_user" "this" {
-  name = var.name
+  for_each = toset(var.users)
+  name     = each.value
 }
 
 resource "aws_iam_user_login_profile" "this" {
-  user                    = aws_iam_user.this.name
+  for_each                = toset(var.users)
+  user                    = aws_iam_user.this[each.key].name
   password_length         = var.password_length
+  password_reset_required = true
 
   # TODO: Remove once https://github.com/hashicorp/terraform-provider-aws/issues/23567 is resolved
   lifecycle {
@@ -16,3 +19,11 @@ resource "aws_iam_user_login_profile" "this" {
   }
 }
 
+resource "aws_iam_group_membership" "this" {
+  name = "admin"
+  users = [
+    for user in aws_iam_user.this : user.name
+  ]
+
+  group = "admin-access"
+}

--- a/aws/modules/bootstrap/outputs.tf
+++ b/aws/modules/bootstrap/outputs.tf
@@ -1,15 +1,4 @@
-output "name" {
-  description = "The user's name"
-  value       = try(aws_iam_user.this.name, "")
-}
-
-output "iam_id" {
-  description = "The unique ID assigned by AWS"
-  value       = try(aws_iam_user.this.unique_id, "")
-}
-
-output "password" {
-  description = "The user password"
-  value       = lookup(try(aws_iam_user_login_profile.this, {}), "password", sensitive(""))
-  sensitive   = true
+output "aws_users" {
+  description = "The list of aws users that have been created."
+  value       = [for user in aws_iam_user.this : user.name]
 }

--- a/aws/modules/bootstrap/variables.tf
+++ b/aws/modules/bootstrap/variables.tf
@@ -1,11 +1,7 @@
-
-#keep
-variable "name" {
-  description = "Desired name for the IAM user"
-  type        = string
+variable "users" {
+  type = list(string)
 }
 
-#keep
 variable "password_length" {
   description = "The length of the generated password"
   type        = number

--- a/aws/prod/tofu.tf
+++ b/aws/prod/tofu.tf
@@ -14,5 +14,5 @@ terraform {
 
 provider "aws" {
   profile = "bc-prod"
-  region = "us-east-1"
+  region  = "us-east-1"
 }


### PR DESCRIPTION
This change modifies the `bootstrap` module to have it create users, login profiles, and make them members of the admin group.

I don't super love having this in the bootstrap module, but it's probably fine for now.

Fixes #9 